### PR TITLE
Draft: Retry failed connections

### DIFF
--- a/src/socketio/client.py
+++ b/src/socketio/client.py
@@ -365,7 +365,6 @@ class Client(object):
         attempt_count = 0
         current_delay = self.reconnection_delay
         while True:
-            self.logger.info("current_delay %i", current_delay)
             if attempt_count > 0 or is_reconnect:
                 delay = min(current_delay, self.reconnection_delay_max)
                 delay += self.randomization_factor * (2 * random.random() - 1)

--- a/src/socketio/client.py
+++ b/src/socketio/client.py
@@ -321,7 +321,7 @@ class Client(object):
         else:
             self._retry_connect(wait, wait_timeout, is_reconnect=False)
 
-    def _connect(self, wait=True, wait_timeout=1):
+    def _connect(self, wait, wait_timeout):
         self.namespaces = {}
         if self._connect_event is None:
             self._connect_event = self.eio.create_event()
@@ -376,7 +376,7 @@ class Client(object):
                     break
                 current_delay *= 2
             try:
-                self._connect()
+                self._connect(wait, wait_timeout)
             except (exceptions.ConnectionError, ValueError) as err:
                 pass
             else:

--- a/tests/common/test_client.py
+++ b/tests/common/test_client.py
@@ -296,8 +296,6 @@ class TestClient(unittest.TestCase):
         c.eio.connect = mock.MagicMock(
             side_effect=[engineio_exceptions.ConnectionError('foo'), None]
         )
-        c.on('foo', mock.MagicMock(), namespace='/foo')
-        c.on('bar', mock.MagicMock(), namespace='/')
         c.connect(
             'url',
             headers='headers',

--- a/tests/common/test_client.py
+++ b/tests/common/test_client.py
@@ -291,6 +291,23 @@ class TestClient(unittest.TestCase):
                 wait=False,
             )
 
+    def test_connect_error_reconnect(self):
+        c = client.Client()
+        c.eio.connect = mock.MagicMock(
+            side_effect=[engineio_exceptions.ConnectionError('foo'), None]
+        )
+        c.on('foo', mock.MagicMock(), namespace='/foo')
+        c.on('bar', mock.MagicMock(), namespace='/')
+        c.connect(
+            'url',
+            headers='headers',
+            transports='transports',
+            socketio_path='path',
+            wait=False,
+            fail_fast=False,
+        )
+        assert c.eio.connect.call_count == 2
+
     def test_connect_twice(self):
         c = client.Client()
         c.eio.connect = mock.MagicMock()

--- a/tests/common/test_client.py
+++ b/tests/common/test_client.py
@@ -985,7 +985,7 @@ class TestClient(unittest.TestCase):
         c._reconnect_task = 'foo'
         c._reconnect_abort = c.eio.create_event()
         c._reconnect_abort.wait = mock.MagicMock(return_value=False)
-        c.connect = mock.MagicMock(
+        c._connect = mock.MagicMock(
             side_effect=[ValueError, exceptions.ConnectionError, None]
         )
         c._handle_reconnect()
@@ -1003,7 +1003,7 @@ class TestClient(unittest.TestCase):
         c._reconnect_task = 'foo'
         c._reconnect_abort = c.eio.create_event()
         c._reconnect_abort.wait = mock.MagicMock(return_value=False)
-        c.connect = mock.MagicMock(
+        c._connect = mock.MagicMock(
             side_effect=[ValueError, exceptions.ConnectionError, None]
         )
         c._handle_reconnect()
@@ -1021,7 +1021,7 @@ class TestClient(unittest.TestCase):
         c._reconnect_task = 'foo'
         c._reconnect_abort = c.eio.create_event()
         c._reconnect_abort.wait = mock.MagicMock(return_value=False)
-        c.connect = mock.MagicMock(
+        c._connect = mock.MagicMock(
             side_effect=[ValueError, exceptions.ConnectionError, None]
         )
         c._handle_reconnect()
@@ -1038,7 +1038,7 @@ class TestClient(unittest.TestCase):
         c._reconnect_task = 'foo'
         c._reconnect_abort = c.eio.create_event()
         c._reconnect_abort.wait = mock.MagicMock(side_effect=[False, True])
-        c.connect = mock.MagicMock(side_effect=exceptions.ConnectionError)
+        c._connect = mock.MagicMock(side_effect=exceptions.ConnectionError)
         c._handle_reconnect()
         assert c._reconnect_abort.wait.call_count == 2
         assert c._reconnect_abort.wait.call_args_list == [


### PR DESCRIPTION
This PR implements the suggestion in #409.

A new option has been added to the `Client.connect` method: `fail_fast`. The default value of `True` is no different to the existing behaviour. If set to false, if the call to connect fails it will be retried using the same logic as for a disconnect.

* I've only implemented this for the synchronous client for now. If it looks good I can port the changes to the async client also.
* I'm not entirely happy with the duplicate default values in `connect/_retry_connect` but I can't see an easy way around this.
* The `fail_fast` name is copied from a similar flag in the `aio-pika` library but could be something else.

